### PR TITLE
Async/await handlers + nodejs24 runtime

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: secret-hitler-role-bot
 
 provider:
   name: aws
-  runtime: nodejs22.x
+  runtime: nodejs24.x
   stage: ${opt:stage, 'dev'}
   apiName: ${self:service}-api
   region: ${self:custom.env-default.REGION, self:custom.env-stage.REGION}

--- a/src/common/logic.js
+++ b/src/common/logic.js
@@ -18,7 +18,7 @@ exports.handleMessage = (user, msg) => {
 }
 
 exports.handleNoMessage = (user) => {
-  user.sendMessage('Something went wrong getting the message to me. Please tell Adam if you see this error.')
+  return user.sendMessage('Something went wrong getting the message to me. Please tell Adam if you see this error.')
 }
 
 function handleDatabase (user, msg) {

--- a/src/handlers/facebook.js
+++ b/src/handlers/facebook.js
@@ -3,72 +3,47 @@
 const userGenerator = require('../common/userGenerator.js')
 const LogicHandler = require('../common/logic.js')
 
-exports.handler = (event, context, callback) => {
+exports.handler = async (event) => {
   // GET request is Facebook performing verification
   if (event.httpMethod === 'GET') {
     const queryParams = event.queryStringParameters
     if (!queryParams || !queryParams['hub.verify_token']) {
-      callback(null, {
-        body: 'Missing validation token',
-        statusCode: 400
-      })
-      return
+      return { body: 'Missing validation token', statusCode: 400 }
     }
 
     if (!queryParams['hub.challenge']) {
-      callback(null, {
-        body: 'Missing challenge',
-        statusCode: 400
-      })
-      return
+      return { body: 'Missing challenge', statusCode: 400 }
     }
 
     if (queryParams['hub.verify_token'] !== process.env.VERIFY_TOKEN) {
-      callback(null, {
-        body: 'Wrong validation token',
-        statusCode: 401
-      })
-      return
+      return { body: 'Wrong validation token', statusCode: 401 }
     }
 
-    callback(null, {
-      body: queryParams['hub.challenge'],
-      statusCode: 200
-    })
+    return { body: queryParams['hub.challenge'], statusCode: 200 }
+  }
 
-    // POST request represents new messages
-  } else if (event.httpMethod === 'POST') {
+  // POST request represents new messages
+  if (event.httpMethod === 'POST') {
     const data = JSON.parse(event.body)
 
     // Make sure this is a page subscription
     if (data.object !== 'page') {
-      callback(null, {
-        body: 'UNSUPPORTED_OPERATION',
-        statusCode: 415
-      })
+      return { body: 'UNSUPPORTED_OPERATION', statusCode: 415 }
     }
 
-    // Iterate over each entry - there may be multiple if batched
-    // e.messaging always only has one event, so take index 0
-    data.entry.map(e => e.messaging[0]).forEach(event => {
-      if (event.message) {
-        handleMessage(event.sender.id, event.message)
-      } else if (event.postback) {
-        handlePostback()
-      } else {
-        callback(null, {
-          body: 'UNSUPPORTED_OPERATION',
-          statusCode: 415
-        })
-      }
-    })
+    // Iterate over each entry - there may be multiple if batched.
+    // e.messaging always only has one event, so take index 0.
+    // Anything other than a message event (e.g. messaging_postbacks) is ignored.
+    await Promise.all(data.entry
+      .map((e) => e.messaging[0])
+      .filter((messagingEvent) => messagingEvent.message)
+      .map((messagingEvent) => handleMessage(messagingEvent.sender.id, messagingEvent.message)))
 
     // Let Facebook know we got the message
-    callback(null, {
-      body: 'EVENT_RECEIVED',
-      statusCode: 200
-    })
+    return { body: 'EVENT_RECEIVED', statusCode: 200 }
   }
+
+  return { body: 'UNSUPPORTED_OPERATION', statusCode: 415 }
 }
 
 // Handles messages events
@@ -79,16 +54,11 @@ function handleMessage (facebookPsid, receivedMessage) {
     firstName: null
   })
 
-  if (!receivedMessage || !receivedMessage.text) {
-    LogicHandler.handleNoMessage(user)
-  } else {
-    const msg = receivedMessage.text
-    console.log("Recieved message '" + msg + "' from user with PSID " + facebookPsid)
-    LogicHandler.handleMessage(user, msg)
+  if (!receivedMessage.text) {
+    return LogicHandler.handleNoMessage(user)
   }
-}
 
-// Handles messaging_postbacks events
-function handlePostback () {
-
+  const msg = receivedMessage.text
+  console.log("Recieved message '" + msg + "' from user with PSID " + facebookPsid)
+  return LogicHandler.handleMessage(user, msg)
 }

--- a/src/handlers/telegram.js
+++ b/src/handlers/telegram.js
@@ -3,33 +3,36 @@
 const userGenerator = require('../common/userGenerator.js')
 const LogicHandler = require('../common/logic.js')
 
-exports.handler = (event, context, callback) => {
+exports.handler = async (event) => {
   // POST request represents new messages
-  if (event.httpMethod === 'POST' && event.body) {
-    const data = JSON.parse(event.body).message
-
-    const user = userGenerator({
-      networkName: 'TELEGRAM',
-      networkScopedId: data.chat.id,
-      firstName: data.from.first_name
-    })
-
-    if (data.chat.type !== 'private') {
-      user.sendMessage('This bot only works in private chats')
-      return
-    };
-
-    if (!data.text) {
-      LogicHandler.handleNoMessage(user)
-    } else {
-      const msg = data.text
-      console.log("Recieved message '" + msg + "' from chat with id " + data.chat.id)
-      LogicHandler.handleMessage(user, msg)
-    }
-
-    callback(null, {
-      body: 'EVENT_RECEIVED',
-      statusCode: 200
-    })
+  if (event.httpMethod !== 'POST' || !event.body) {
+    return { body: 'UNSUPPORTED_OPERATION', statusCode: 415 }
   }
+
+  // Updates without a plain message (e.g. edited_message, channel_post) are
+  // acknowledged and ignored — anything but a 200 makes Telegram retry the update
+  const data = JSON.parse(event.body).message
+  if (!data || !data.chat || !data.from) {
+    return { body: 'EVENT_RECEIVED', statusCode: 200 }
+  }
+
+  const user = userGenerator({
+    networkName: 'TELEGRAM',
+    networkScopedId: data.chat.id,
+    firstName: data.from.first_name
+  })
+
+  if (data.chat.type !== 'private') {
+    await user.sendMessage('This bot only works in private chats')
+    return { body: 'EVENT_RECEIVED', statusCode: 200 }
+  }
+
+  if (!data.text) {
+    await LogicHandler.handleNoMessage(user)
+  } else {
+    console.log("Recieved message '" + data.text + "' from chat with id " + data.chat.id)
+    await LogicHandler.handleMessage(user, data.text)
+  }
+
+  return { body: 'EVENT_RECEIVED', statusCode: 200 }
 }


### PR DESCRIPTION
The nodejs24 Lambda runtime ([LTS until April 2028](https://aws.amazon.com/blogs/compute/node-js-24-runtime-now-available-in-aws-lambda/)) dropped callback-style handlers, which was the blocker for going past nodejs22 in #71. Both handlers are now async functions returning the response object.

Beyond the runtime unlock, this fixes real bugs — the old handlers had paths that never called `callback`, so API Gateway returned **502**, and Telegram retries any non-200 (potentially forever):

- **telegram**: non-POST/empty-body, updates without a `message` key (`edited_message`, `channel_post`), and the group-chat path all now respond. Message-less updates are acked with 200 so Telegram stops redelivering them.
- **facebook**: the non-page 415 previously fell through into entry processing (and the per-entry 415 raced the final `EVENT_RECEIVED` callback, first-call-wins). Now: clean early return, unsupported messaging events ignored, sends awaited before responding — required in async style, where returning early would freeze in-flight sends.
- `logic.handleNoMessage` now returns its promise so handlers can genuinely await it.

Verified on the deployed dev stage running nodejs24.x:
- FB handshake with real verify token → challenge echo, 200; wrong token → 401
- Telegram `/help` → `EVENT_RECEIVED` 200
- The three previously-502 paths (group chat, `edited_message`, empty JSON) → all 200
- 31/31 vitest tests pass