### PR TITLE
Switch CD to GitHub OIDC (WIF)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,6 +3,10 @@ name: CI/CD
 on:
   push:
 
+permissions:
+  id-token: write # mint the GitHub OIDC token used to assume the AWS role
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -10,11 +14,11 @@ jobs:
       CI: true
     steps:
       - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - name: Install dependencies
         run: npm ci
       - name: Lint
@@ -28,16 +32,19 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ENVYML: ${{ secrets.ENVYML }}
     steps:
       - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::338337944728:role/shrolebot-ci
+          aws-region: eu-west-2
       - name: Install dependencies
         run: npm ci
       - name: Create env.yml


### PR DESCRIPTION
cd assumes the federated `shrolebot-ci` role (minted in [aws-shared-infra#1](https://github.com/domdomegg/aws-shared-infra/pull/1), trust pinned to this repo's master) instead of the `serverless` user's 2021 access key. The `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets will be deleted after the first federated deploy is verified green on master. `ENVYML` stays — it's app config, not AWS auth.

Also bumps `actions/checkout`/`setup-node` to v4 (the v1s were hitting deprecation warnings) and CI node to 24, matching the Lambda runtime.